### PR TITLE
LAVA Web server for RISC-V boot and deployment

### DIFF
--- a/Lava_job_template/supply-uboot-proper.yaml
+++ b/Lava_job_template/supply-uboot-proper.yaml
@@ -1,0 +1,85 @@
+# LAVA Job Definition: Flash uboot-opensbi.itb via UART YMODEM
+
+# ====================================================================
+# Job Metadata
+# ====================================================================
+
+job_name: 3 - Flash of bootloader on SD card using uuu - u-boot only (health-check)
+device_type: banana-pi-f3 # This must match the 'device_type' defined in your device dictionary
+timeouts:
+  job:
+    minutes: 12 # Overall job timeout
+visibility: public # Or 'private' if you prefer
+
+# ====================================================================
+# LAVA Actions
+# ====================================================================
+actions:
+  # 1. Deploy the .itb image (LAVA downloads it to the dispatcher's temp directory)
+  - deploy:
+      timeout:
+        minutes: 7
+      to: downloads # Or 'tmpfs'. 'download' is often more explicit.
+      images:
+        image: # Name for the image
+          url: file:///uboot-opensbi_buildroot.itb # 
+        uImage:
+          url: https://github.com/alitariq4589/k1-kernelci-setup/blob/main/images/uImage-bianbu
+        dtb:
+          url: https://github.com/alitariq4589/k1-kernelci-setup/blob/main/images/k1-x_deb1_cloud_v.dtb
+        ramdisk:
+          url: https://github.com/alitariq4589/k1-kernelci-setup/blob/main/images/initramfs-generic.img
+        rootfs:
+          url: http://github.com/alitariq4589/k1-kernelci-setup/releases/tag/buildroot/rootfs.ext2
+  - deploy:
+      timeout:
+        minutes: 10
+      to: flasher # Or 'tmpfs'. 'download' is often more explicit.
+      images:
+        image: # Name for the boot image
+          url: downloads://uboot-opensbi_buildroot.itb
+
+  # 2. Boot the device and perform the UART YMODEM flash
+  - boot:
+       method: u-boot
+       transfer_overlay:
+          download_command: cd /tmp ; wget
+          unpack_command: none
+       commands:
+       - "setenv ipaddr 192.168.2.5"
+       - "setenv serverip 192.168.2.2"
+       - "setenv netmask 255.255.255.0"
+       - "setenv gatewayip 192.168.2.2"
+       - "setenv dtb_addr 0x31000000"
+       - "setenv ramdisk_addr 0x21000000"
+       - "setenv fdt_high 0xffffffffffffffff"
+       - "setenv kernel_addr_r 0x11000000"
+       - "setenv rootfs_path /nfsroot/rootfs"
+       - "setenv bootfs_path /nfsroot/bootfs"
+       - "setenv rootpath /nfsroot/rootfs"
+       - "setenv console ttyS0,115200"
+       - "setenv dtb_name k1-x_deb1_cloud_v.dtb"
+       - "setenv ramdisk_name initramfs-generic.img"
+       - "setenv knl_name uImage-bianbu"
+       - "workqueue.default_affinity_scope=system"
+       - "commonargs=setenv bootargs ${console}  earlyprintk quiet splash plymouth.ignore-serial-consoles plymouth.prefer-fbcon clk_ignore_unused swiotlb=65536 workqueue.default_affinity_scope=${workqueue.default_affinity_scope}"
+       - "setenv get_kernel 'echo \"Loading kernel from NFS...\"; nfs ${kernel_addr_r} ${serverip}:${bootfs_path}/${knl_name}'"
+       - "setenv get_dtb 'echo \"Loading dtb from NFS...\"; nfs ${dtb_addr} ${serverip}:${bootfs_path}/${dtb_name}'"
+       - "setenv get_ramdisk 'nfs ${ramdisk_addr} ${serverip}:${bootfs_path}/${ramdisk_name}; setenv ramdisk_size ${filesize}; setenv ramdisk_combo ${ramdisk_addr}:${ramdisk_size}'"
+       - "setenv set_boot_args 'setenv bootargs \"${bootargs}\" root=/dev/nfs nfsroot=${serverip}:${rootfs_path} bootfs=${serverip}:${bootfs_path} rootpath=/ ip=${ipaddr}:${serverip}:${gatewayip}:${netmask}::${netdev}:off noipath'"
+       - "setenv start_kernel 'fdt addr ${dtb_addr}; if fdt list /; then bootm ${kernel_addr_r} ${ramdisk_combo} ${dtb_addr}; else booti ${kernel_addr_r} ${ramdisk_combo} ${dtb_addr}; fi;'"
+       - "setenv nfs_boot 'echo \"Try to boot from NFS ...\"; run commonargs; run set_boot_args; run get_kernel; run get_dtb; run get_ramdisk; run start_kernel; echo \"########### boot kernel failed from NFS, check your boot config #############\"'"
+       - "fdt addr ${dtb_addr}"
+       - "run nfs_boot"
+
+       auto_login: 
+          login_prompt: 'Bianbu login:'
+          username: 'root'
+          password: 'bianbu'
+       prompts:
+       - 'Welcome to Bianbu Linux'
+
+       reset: false # Do not reset the device after booting 
+       timeout:
+          minutes: 10
+

--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ Documentation chronological sequence is as follows.
 
 - Describes how to add a newer physical board in LAVA worker and then add it in the lava-server
 - Describes how to set up PDU with arduino uno and relays 
+
+## [LAVA Web-Server for RISCV boot and deployment](/docs/Lava-bpi-f3-bootflow.md):
+- Setting up Banana Pi F3 Boot Flow for Kernel CI
+  - U-Boot Secondary Program Loader (SPL) Setup
+  - U-Boot environment for BPI-F3
+  - Host Machine NFS Server Setup
+  - Booting the Linux kernel on BPI-F3
+- Automating with LAVA Job (.yaml) File

--- a/docs/Lava-bpi-f3-bootflow.md
+++ b/docs/Lava-bpi-f3-bootflow.md
@@ -1,0 +1,65 @@
+# **Setting up Banana Pi F3 Boot Flow for Kernel CI**
+This document outlines the essential steps to integrate the Banana Pi F3 board into a 10xKernel CI (Continuous Integration) environment using LAVA (Linaro Automated Validation Architecture). 
+It details the setup required on a host x86 machine to enable LAVA to deploy binaries to the device, initiate booting, and validate the Linux kernel.
+
+## U-Boot Secondary Program Loader (SPL) Setup
+The first stage bootloader for kernelCI setup is the u-boot SPL (secondary program loader) which remains in the emmc and polls for u-boot proper from the UART Y-modem. 
+It is built separately. It places the u-boot proper at the certain address in the volatile memory and then jumps to it.
+Once the U-Boot proper is running, you can leverage its extensive command set, as described in the **U-Boot environment for BPI-F3**, to load the Linux kernel, often via NFS.
+All required images are available in [firmware_images](https://github.com/alitariq4589/k1-kernelci-setup/tree/main/images)
+Firmware image is available in [opensbi_buildroot](https://github.com/alitariq4589/k1-kernelci-setup/blob/main/firmware/uboot-opensbi_buildroot.itb)
+
+## U-Boot environment for BPI-F3
+Upon entering the U-Boot state, a series of commands are executed to configure the necessary U-Boot environment variables. 
+These variables are crucial for network setup, memory addressing, and boot processes.
+Refer to the [u-boot-env](https://github.com/alitariq4589/k1-kernelci-setup/blob/main/u-boot-env.env) for the list of commands.
+
+## Host Machine NFS Server Setup
+To enable the Banana Pi F3 board to download kernel images and root filesystems via NFS from the host machine, follow these steps to configure your NFS server:
+1. Install NFS server package:
+   **sudo apt update **
+   ** sudo apt install nfs-kernel-server**
+2. Create the following directories to export:
+   **/nfsroot/rootfs** and **/nfsroot/bootfs**
+3. Configure the NFS exports
+   Edit **/etc/exports** and add lines like:
+   /nfsroot/bootfs    *(rw,sync,no_subtree_check,no_root_squash)
+   /nfsroot/roottfs   *(rw,sync,no_subtree_check,no_root_squash)
+   Note: For NFS directory setup, refer to [MOUNTING_NFS](https://github.com/alitariq4589/k1-kernelci-setup/blob/main/docs/MOUNTING_NFS.md)
+4. Export the directory:
+   After modifying /etc/exports, apply the changes by running: **sudo exportfs -ra**
+   NOTE: Only NFS version 3 is supported by u-boot for file transfering through nfs and also udp support needs to be enabled.
+
+5. Enable NFSv3 and UDP (Crucial for U-Boot):
+   U-Boot commonly supports only NFS version 3 for file transfers, and UDP support must be enabled. To ensure this:
+   Open /etc/nfs.conf file and add this change "**vers3=y**" and **"udp=y"**, save this file.
+
+7. Start and enable the NFS server:
+   **sudo systemctl restart nfs-kernel-server**
+   **sudo systemctl enable nfs-kernel-server**  
+
+
+## Booting the Linux kernel on BPI-F3
+Once the NFS server is successfully configured and running, and the U-Boot environment variables are set (typically after transferring "uboot-opensbi_buildroot.itb" to the board using the Y-modem UART transfer protocol), 
+the system is ready to boot the Linux kernel.
+After the U-Boot proper is loaded, execute the custom U-Boot command **"nfs_boot"** (as defined in u-boot-env.env).
+This command initiates the transfer of all necessary firmware images and the kernel via NFS to the board, subsequently starting the Linux kernel. 
+A successful kernel boot will typically display a log similar to this on the serial terminal:
+**Welcome to Bianbu Linux
+Bianbu login: [   39.985206] ldo5: disabling**
+
+# **Automating with LAVA Job (.yaml) File**
+All the manual steps described above for "board bring-up" and "booting Linux kernel" can be fully automated using a LAVA job. This allows for continuous, remote testing and validation.
+1. **Adding Banana Pi F3 as a device in LAVA:**
+   Follow the instructions detailed in [Adding BPI-F3 as device](https://github.com/alitariq4589/lava-webserver-riscv/blob/main/docs/ADDING_BPI-F3.md) to register Banana Pi F3 board with LAVA instance.
+2. **Setup device dictionary**:
+   Configure the device-specific parameters using a LAVA device dictionary. An example configuration bpi-f3 board can be found in [**bpi-f3.jinja2**](https://github.com/alitariq4589/lava-webserver-riscv/blob/main/device_templates/bpi-f3.jinja2)
+   This file will define variables and settings specific to the Banana Pi F3.
+3. **Create the LAVA Job File:**
+   Write a LAVA job definition (.yaml file) that outlines the desired actions. This file will orchestrate the U-Boot SPL setup and the Linux kernel booting process. 
+   The boot action within the LAVA job will include the U-Boot commands (like setenv and nfs_boot) to be executed on the device's console.for intended actions (in this case setup u-boot SPL and builds Linux kernel).
+4. **Submit the LAVA Job:**
+   Submit the job using "_lavacli -i lava jobs submit job.yaml_" command
+5. **Automated Execution:**
+   The LAVA server will automatically schedule and execute the job, managing the entire boot and kernel validation process on the Banana Pi F3.
+


### PR DESCRIPTION
1. Updated README.md to add a separate section explaining LAVA Web-Server for RISCV boot and deployment,
2. Added a supported document in /docs folder to explain the procedure in detail with required steps
3. Also added a reference LAVA job YAML file which can be used to automatically deploy pre-compiled binaries on device via LAVA dispatcher.